### PR TITLE
Retorno Bradesco 400 documentação

### DIFF
--- a/cnab400/237/retorno/detalhe.yml
+++ b/cnab400/237/retorno/detalhe.yml
@@ -33,8 +33,8 @@ zeros03:
   picture: '9(8)'
 
 nosso_numero:
-  pos: [71, 82]
-  picture: '9(12)'
+  pos: [71, 81]
+  picture: '9(11)'
 
 uso_banco01:
   pos: [83, 92]


### PR DESCRIPTION
No retorno bradesco o nosso_numero é da possição 71 a 82 mas, onde este já vem no retorno com o digito verificador logo o ultimo digito é o dv, mas o grande problema é que em alguns casos o dv é o "P" logo ao capturar o retorno é considerado apenas do "71 a 81" pois o p não é um número, ai eu pergunto para deixar um comportamento padrão o ideal não seria deixar sempre da posição 71 a 81 desconsiderando o dv? já que quando for dv "P" ele desconsidera mas quando é numero não desconsidera ai está dificil de tratrar o retorno. o que acham?